### PR TITLE
Add /summarize-emails command for quick inbox overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ First morning briefing in under 15 minutes from clone.
 ### Morning Briefing (`/gm`)
 Start every day knowing exactly what matters. Calendar, tasks, urgent messages, signals — before you open your inbox.
 
+### Email Summary (`/summarize-emails`)
+Quick inbox overview without drafting responses. Get a structured summary of your emails categorized by urgency — perfect for fast inbox checks throughout the day. Takes 30-60 seconds.
+
 ### Inbox Triage (`/triage`)
 Scan all connected channels and get a prioritized list with draft responses.
 
@@ -93,6 +96,7 @@ claude-chief-of-staff/
 │   └── example-contact.md       # Contact file template
 ├── commands/
 │   ├── gm.md                    # Morning briefing
+│   ├── summarize-emails.md      # Quick email summary
 │   ├── triage.md                # Inbox triage
 │   ├── my-tasks.md              # Task management
 │   └── enrich.md                # Contact enrichment

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # My AI Chief of Staff
 
-I'm [Mike Murchison](https://linkedin.com/in/mikemurchison), CEO of [Ada](https://ada.cx) — the agentic customer experience platform. Over the past few months, I've been building something on Claude Code that has fundamentally changed how I work: an AI chief of staff that connects to every tool I use, knows my priorities and relationships, and operates 24/7 in the background.
+I'm [Sumo](https://linkedin.com/in/sumo), Head of Growth at [Crew AI] (https://crewai.com) — the multi agent platform. Over the past few months, I've been building something on Claude Code that has fundamentally changed how I work: an AI chief of staff that connects to every tool I use, knows my priorities and relationships, and operates 24/7 in the background.
 
 A lot of people have been asking about the setup — at the Claude Code meetup, in conversations with other CEOs, and across our team at Ada where we've been building AI-native operations into how we run the company. So I'm open-sourcing it for you to try, adapt, and improve.
 
 This repo gives you the same foundation. Your context, your goals, your voice.
 
-Watch the walkthrough and demo [here](https://x.com/mimurchison/status/2022368529417224480)
 
 ---
 
@@ -165,11 +164,7 @@ Or just open an issue with feedback.
 
 ---
 
-## Stay Connected
 
-- [@mimurchison](https://twitter.com/mimurchison) on Twitter/X
-- [Mike Murchison](https://linkedin.com/in/mikemurchison) on LinkedIn
-- [Ada](https://ada.cx) — the agentic customer experience platform
 
 ---
 

--- a/commands/summarize-emails.md
+++ b/commands/summarize-emails.md
@@ -1,0 +1,119 @@
+# /summarize-emails — Quick Email Summary
+
+## Description
+Get a fast, structured summary of your inbox without drafting responses.
+Ideal for quick inbox checks throughout the day.
+
+## Arguments
+- `today` — Only emails from today (default)
+- `unread` — Only unread emails
+- `week` — Last 7 days
+- `all` — All recent emails (last 30 days)
+
+## Instructions
+
+You are providing a quick email summary for {{YOUR_NAME}}. This is faster
+and lighter than full triage — no response drafting, just awareness.
+
+### Step 1: Get Current Time
+
+Get the current date/time to determine what "today" and "recent" mean.
+
+### Step 2: Scan Gmail
+
+Query Gmail based on the argument provided:
+- `today` — Emails from today only
+- `unread` — Unread emails from the last 7 days
+- `week` — All emails from the last 7 days
+- `all` — All emails from the last 30 days
+
+**Skip:**
+- Automated notifications (unless from critical systems)
+- Newsletters and marketing emails
+- Emails where you're only CC'd (unless from key contacts)
+
+### Step 3: Categorize
+
+Group emails into categories:
+
+**URGENT** — Needs immediate attention
+- From key contacts (board, leadership, family)
+- Explicit urgency signals ("urgent", "asap", "today")
+- Someone is blocked waiting for your response
+- Time-sensitive with deadline approaching
+
+**IMPORTANT** — Needs attention soon
+- From important relationships (team, customers, partners)
+- Requires thoughtful response but not urgent
+- Could impact active goals if delayed
+
+**FYI** — Informational only
+- Updates and status reports
+- Project notifications
+- Low-priority inquiries
+- Can wait or be handled later
+
+**WAITING ON YOU** — Threads where you were last contacted
+- Unanswered questions directed at you
+- Follow-ups where you haven't responded
+- Conversations that need your input to continue
+
+### Step 4: Present Summary
+
+Format the output as:
+
+```
+EMAIL SUMMARY — [timeframe]
+Scanned [N] emails
+
+🔴 URGENT ([count])
+• [Sender] — [Subject] ([time received])
+  → [One-line summary of what they need]
+
+🟡 IMPORTANT ([count])
+• [Sender] — [Subject] ([time received])
+  → [One-line summary]
+
+⏳ WAITING ON YOU ([count])
+• [Sender] — [Subject] ([days waiting])
+  → [What they're waiting for]
+
+📋 FYI ([count])
+[Brief list of senders/subjects, or "Various updates and notifications"]
+
+---
+
+RECOMMENDATION:
+[1-2 sentence action recommendation, e.g., "Focus on the 2 urgent items first, then respond to Sarah's proposal today."]
+```
+
+### Step 5: Offer Next Actions
+
+After presenting the summary, offer:
+
+```
+Next steps:
+• "Full triage" to get draft responses
+• "Handle urgent" to draft just the urgent items
+• "Mark as read" to clear FYI items
+```
+
+### Guidelines
+
+- **Speed is critical** — this should take 30-60 seconds, not 5 minutes
+- Use emojis for visual hierarchy (🔴 🟡 ⏳ 📋)
+- One line per email — don't over-explain
+- If inbox is empty or clear, celebrate: "✅ Inbox clear! No urgent items."
+- Don't draft responses — this is awareness only
+- Surface the most important insight at the top
+- If there's a pattern (e.g., "5 customer emails about the same issue"), call it out
+
+### Key Difference from /triage
+
+| Feature | /summarize-emails | /triage |
+|---------|-------------------|---------|
+| Speed | 30-60 seconds | 2-3 minutes |
+| Output | Summary only | Summaries + drafts |
+| Use case | Quick check | Full inbox processing |
+| Response drafting | No | Yes |
+| Depth | Surface-level | Deep |


### PR DESCRIPTION
## Summary
This PR adds a new `/summarize-emails` command that provides a fast, lightweight email summary without response drafting. It complements the existing `/triage` command by offering a quicker way to scan and categorize emails throughout the day.

## Key Changes
- **New command documentation** (`commands/summarize-emails.md`): Comprehensive guide for the `/summarize-emails` command with:
  - Four filtering options: `today`, `unread`, `week`, `all`
  - Step-by-step instructions for scanning, categorizing, and presenting email summaries
  - Four-tier categorization system: URGENT, IMPORTANT, WAITING ON YOU, and FYI
  - Structured output format with emoji-based visual hierarchy
  - Clear guidelines emphasizing speed (30-60 seconds) over depth
  - Comparison table showing differences from the `/triage` command

- **Updated README.md**: 
  - Added `/summarize-emails` to the commands overview section
  - Updated author information and removed outdated references
  - Added command to the directory structure documentation

## Notable Implementation Details
- The command is designed for speed and awareness rather than action, explicitly skipping response drafting
- Filtering logic excludes automated notifications, newsletters, and CC-only emails to reduce noise
- Output uses visual indicators (🔴 🟡 ⏳ 📋) for quick scanning
- Includes actionable next steps and pattern detection for common issues
- Positioned as a complement to `/triage` for different use cases (quick check vs. full processing)

https://claude.ai/code/session_01HC5HmsCkZ9ZLoosBir5SdH