### PR TITLE
Add Telegram bot for mobile access to AI Chief of Staff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ cache/
 local/
 *.local.md
 *.local.yaml
+
+# Telegram bot secrets
+telegram/.env
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ A personal CRM that builds itself. 160+ contacts tracked, auto-enriched every 15
 ### 4. Achieve Goals
 Define your quarterly objectives. Every triage decision, scheduling recommendation, and task prioritization is filtered through what you said matters most. Claude tells me when my calendar doesn't match my goals.
 
+### 5. Mobile Access
+Your full AI Chief of Staff in your pocket. A Telegram bot bridges your phone to the Claude Code CLI running on your Mac. All MCP servers, commands, and context — accessible from anywhere.
+
 ---
 
 ## Quick Start
@@ -97,9 +100,15 @@ claude-chief-of-staff/
 │   ├── triage.md                # Inbox triage
 │   ├── my-tasks.md              # Task management
 │   └── enrich.md                # Contact enrichment
+├── telegram/
+│   ├── cheef_bot.py                        # Telegram-to-Claude bridge
+│   ├── com.cheef.telegram.plist.template   # macOS service template
+│   ├── .env.example                        # Credentials template
+│   └── requirements.txt                    # Python dependencies
 └── docs/
     ├── setup-guide.md           # Detailed setup walkthrough
     ├── mcp-servers.md           # MCP server installation
+    ├── telegram-setup.md        # Telegram bot setup
     └── customization.md         # Make it yours
 ```
 

--- a/docs/telegram-setup.md
+++ b/docs/telegram-setup.md
@@ -1,0 +1,167 @@
+# Telegram Bot Setup
+
+The Telegram bot gives you mobile access to your AI Chief of Staff. Send a message from your phone and get a response powered by Claude Code — with all your MCP servers, context, and commands available.
+
+---
+
+## Prerequisites
+
+- Claude Code CLI installed and working locally (`claude --version`)
+- Telegram account
+- macOS (the background service uses launchd; the bot itself runs on any Unix)
+
+---
+
+## Step 1: Create a Telegram Bot
+
+1. Open Telegram and search for **@BotFather**
+2. Send `/newbot`
+3. Follow the prompts — choose a name and username for your bot
+4. BotFather gives you a **bot token** (looks like `7123456789:AAF...`)
+5. Save this token
+
+---
+
+## Step 2: Get Your Telegram User ID
+
+You must whitelist your own Telegram user ID so only you can use the bot.
+
+1. Open Telegram and search for **@userinfobot**
+2. Send `/start`
+3. It replies with your numeric user ID (e.g., `123456789`)
+4. Save this number
+
+---
+
+## Step 3: Install
+
+If you haven't run the installer yet:
+
+```bash
+./install.sh
+```
+
+When prompted "Set up Telegram bot?", type `y`. The installer will copy bot files to `~/.claude/telegram/`, install Python dependencies, and optionally install a launchd service.
+
+**If you already ran the installer without Telegram**, set it up manually:
+
+```bash
+mkdir -p ~/.claude/telegram
+cp telegram/cheef_bot.py ~/.claude/telegram/
+cp telegram/requirements.txt ~/.claude/telegram/
+cp telegram/.env.example ~/.claude/telegram/.env.example
+pip3 install -r ~/.claude/telegram/requirements.txt
+```
+
+---
+
+## Step 4: Configure Credentials
+
+```bash
+cp ~/.claude/telegram/.env.example ~/.claude/telegram/.env
+```
+
+Edit `~/.claude/telegram/.env`:
+
+```bash
+TELEGRAM_BOT_TOKEN=7123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ALLOWED_TELEGRAM_USER_ID=123456789
+CHEEF_PROJECT_DIR=/Users/yourname/claude-chief-of-staff
+CLAUDE_BIN=/opt/homebrew/bin/claude
+```
+
+| Variable | Description |
+|----------|-------------|
+| `TELEGRAM_BOT_TOKEN` | From BotFather (Step 1) |
+| `ALLOWED_TELEGRAM_USER_ID` | Your Telegram user ID (Step 2) |
+| `CHEEF_PROJECT_DIR` | Path to your cloned `claude-chief-of-staff` folder |
+| `CLAUDE_BIN` | Path to Claude binary — find it with `which claude` |
+
+---
+
+## Step 5: Test Manually First
+
+```bash
+python3 ~/.claude/telegram/cheef_bot.py
+```
+
+Open Telegram, find your bot by username, and send `/start`. You should see the welcome message. Send any message — it should route through Claude and reply.
+
+Press `Ctrl+C` to stop.
+
+---
+
+## Step 6: Install as a Background Service (macOS)
+
+To run the bot automatically and keep it running after restarts:
+
+```bash
+# Substitute your home directory into the template
+sed "s|{{HOME_DIR}}|$HOME|g" \
+    telegram/com.cheef.telegram.plist.template \
+    > ~/Library/LaunchAgents/com.cheef.telegram.plist
+
+# Load the service
+launchctl load ~/Library/LaunchAgents/com.cheef.telegram.plist
+```
+
+The bot will now start automatically when you log in.
+
+---
+
+## Managing the Service
+
+```bash
+# Stop the bot
+launchctl unload ~/Library/LaunchAgents/com.cheef.telegram.plist
+
+# Start the bot
+launchctl load ~/Library/LaunchAgents/com.cheef.telegram.plist
+
+# Check if it's running
+launchctl list | grep cheef
+
+# View logs
+tail -f ~/.claude/telegram/cheef_bot.log
+tail -f ~/.claude/telegram/cheef_bot_error.log
+```
+
+---
+
+## Available Commands
+
+| Command | What it does |
+|---------|-------------|
+| `/start` | Show welcome message |
+| `/clear` | Reset conversation context |
+| `/gm` | Morning briefing |
+| `/triage` | Inbox triage |
+| `/my_tasks` | Task list |
+| Any message | Routes to Claude — ask anything |
+
+---
+
+## Troubleshooting
+
+**Bot doesn't respond**
+1. Check it's running: `launchctl list | grep cheef`
+2. Check logs: `tail -50 ~/.claude/telegram/cheef_bot_error.log`
+3. Verify token and user ID in `~/.claude/telegram/.env`
+
+**"Claude CLI not found" error**
+Set `CLAUDE_BIN` in your `.env` to the absolute path. Find it with: `which claude`
+
+**Responses time out**
+Claude can take up to 3 minutes when MCP servers are slow. If consistently timing out, try a simpler request or verify MCP servers are working in a regular Claude Code session.
+
+**Bot works manually but not as a service**
+The launchd service needs an absolute `CLAUDE_BIN` path. Verify it in your `.env` and confirm the binary exists at that location.
+
+---
+
+## Security Notes
+
+- Your `.env` file contains sensitive credentials — it is gitignored by default
+- Never commit your `.env` file
+- The bot silently rejects all users except your whitelisted user ID
+- All Claude invocations run with your local permissions and full MCP access

--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,59 @@ for cmd in "$SCRIPT_DIR/commands/"*.md; do
     fi
 done
 
+# ── Optional: Telegram bot setup ─────────────────────────────────────────────
+echo ""
+echo -e "${BLUE}Optional: Telegram bot${NC} — message your AI Chief of Staff from your phone"
+echo ""
+read -p "Set up Telegram bot? (y/n) " -n 1 -r
+echo
+TELEGRAM_INSTALLED=false
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    TELEGRAM_DIR="$CLAUDE_DIR/telegram"
+    mkdir -p "$TELEGRAM_DIR"
+
+    copy_if_missing "$SCRIPT_DIR/telegram/cheef_bot.py"     "$TELEGRAM_DIR/cheef_bot.py"
+    copy_if_missing "$SCRIPT_DIR/telegram/requirements.txt" "$TELEGRAM_DIR/requirements.txt"
+
+    if [ ! -f "$TELEGRAM_DIR/.env" ]; then
+        cp "$SCRIPT_DIR/telegram/.env.example" "$TELEGRAM_DIR/.env.example"
+        echo "  Created: $TELEGRAM_DIR/.env.example"
+        echo -e "  ${YELLOW}Action required:${NC} Rename to .env and fill in your credentials"
+    else
+        echo -e "  ${YELLOW}Skipped (already exists):${NC} $TELEGRAM_DIR/.env"
+    fi
+
+    echo ""
+    echo -e "${GREEN}Installing Python dependencies...${NC}"
+    if command -v pip3 &> /dev/null; then
+        pip3 install -q -r "$TELEGRAM_DIR/requirements.txt"
+        echo "  Dependencies installed."
+    else
+        echo -e "  ${YELLOW}pip3 not found — install manually:${NC}"
+        echo "  pip3 install -r $TELEGRAM_DIR/requirements.txt"
+    fi
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo ""
+        read -p "Install as background service (auto-start on login)? (y/n) " -n 1 -r
+        echo
+        PLIST_DEST="$HOME/Library/LaunchAgents/com.cheef.telegram.plist"
+        sed "s|{{HOME_DIR}}|$HOME|g" "$SCRIPT_DIR/telegram/com.cheef.telegram.plist.template" > "$PLIST_DEST"
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            launchctl load "$PLIST_DEST" 2>/dev/null || true
+            echo "  Service loaded. Bot auto-starts on login."
+            echo -e "  ${YELLOW}Note:${NC} Bot won't work until you fill in $TELEGRAM_DIR/.env"
+        else
+            echo "  Plist written to: $PLIST_DEST"
+            echo "  To start later: launchctl load $PLIST_DEST"
+        fi
+    fi
+
+    TELEGRAM_INSTALLED=true
+else
+    echo "  Skipped. See docs/telegram-setup.md to add it later."
+fi
+
 # Summary
 echo ""
 echo -e "${BOLD}============================================${NC}"
@@ -139,6 +192,9 @@ echo "  my-tasks.yaml      — Task tracking"
 echo "  schedules.yaml     — Automation schedules"
 echo "  contacts/          — Contact files"
 echo "  commands/          — Skill definitions (gm, triage, my-tasks, enrich)"
+if [ "$TELEGRAM_INSTALLED" = true ]; then
+    echo "  telegram/          — Telegram bot for mobile access"
+fi
 echo ""
 echo -e "${BOLD}Next steps:${NC}"
 echo ""
@@ -158,6 +214,12 @@ echo "     > /gm            # Morning briefing"
 echo "     > /triage         # Inbox triage"
 echo "     > /my-tasks list  # See your tasks"
 echo ""
+if [ "$TELEGRAM_INSTALLED" = true ]; then
+    echo -e "  ${BLUE}5.${NC} Finish Telegram setup:"
+    echo "     Rename $CLAUDE_DIR/telegram/.env.example to .env and fill in credentials"
+    echo "     See docs/telegram-setup.md for details"
+    echo ""
+fi
 echo -e "${YELLOW}Tip:${NC} The more you customize CLAUDE.md, the better Claude performs."
 echo "     Spend 30 minutes filling in your writing style examples and team info."
 echo ""

--- a/telegram/.env.example
+++ b/telegram/.env.example
@@ -1,0 +1,13 @@
+# Rename this file to .env and fill in your values.
+# NEVER commit the .env file — it contains sensitive credentials.
+#
+# How to get your values:
+#   TELEGRAM_BOT_TOKEN:       Message @BotFather on Telegram → /newbot
+#   ALLOWED_TELEGRAM_USER_ID: Message @userinfobot on Telegram → /start
+#   CHEEF_PROJECT_DIR:        Path to your cloned claude-chief-of-staff folder
+#   CLAUDE_BIN:               Run `which claude` in your terminal
+
+TELEGRAM_BOT_TOKEN=7123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ALLOWED_TELEGRAM_USER_ID=123456789
+CHEEF_PROJECT_DIR=/Users/yourname/claude-chief-of-staff
+CLAUDE_BIN=/opt/homebrew/bin/claude

--- a/telegram/cheef_bot.py
+++ b/telegram/cheef_bot.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Cheef Telegram Bot
+Bridges Telegram to Claude Code CLI running locally on Mac.
+
+Setup:
+1. Create ~/.claude/telegram/.env with TELEGRAM_BOT_TOKEN and ALLOWED_TELEGRAM_USER_ID
+2. pip3 install "python-telegram-bot[job-queue]>=20.0" python-dotenv
+3. Run manually first to test: python3 cheef_bot.py
+4. Then install as launchd service for persistence
+"""
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+from collections import defaultdict, deque
+from pathlib import Path
+
+from dotenv import load_dotenv
+from telegram import Update
+from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+load_dotenv(Path.home() / ".claude" / "telegram" / ".env")
+
+BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
+ALLOWED_USER_ID = int(os.environ["ALLOWED_TELEGRAM_USER_ID"])
+PROJECT_DIR = os.environ.get(
+    "CHEEF_PROJECT_DIR",
+    str(Path.home() / "claude-chief-of-staff")
+)
+CLAUDE_BIN = os.environ.get(
+    "CLAUDE_BIN",
+    subprocess.run(["which", "claude"], capture_output=True, text=True).stdout.strip()
+    or "/opt/homebrew/bin/claude"
+)
+MAX_HISTORY_TURNS = 10                   # rolling window of message pairs
+TELEGRAM_MAX_CHARS = 4000               # slightly under 4096 for safety
+CLAUDE_TIMEOUT = 180.0                  # seconds — MCP calls can be slow
+
+LOG_FILE = str(Path.home() / ".claude" / "telegram" / "cheef_bot.log")
+
+logging.basicConfig(
+    format="%(asctime)s — %(levelname)s — %(message)s",
+    level=logging.INFO,
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(),        # also print to stdout for manual testing
+    ]
+)
+logger = logging.getLogger(__name__)
+
+# ── Conversation History ───────────────────────────────────────────────────────
+# In-memory rolling history per chat_id.
+# Claude CLI -p mode is stateless per invocation, so we inject context manually.
+conversation_history: dict[int, deque] = defaultdict(lambda: deque(maxlen=MAX_HISTORY_TURNS * 2))
+
+
+def build_prompt_with_history(chat_id: int, new_message: str) -> str:
+    """Prepend recent conversation turns to the new message for context continuity."""
+    history = list(conversation_history[chat_id])
+    if not history:
+        return new_message
+
+    lines = []
+    for entry in history:
+        prefix = "Human" if entry["role"] == "user" else "Assistant"
+        content = entry["content"]
+        # Truncate old turns to avoid excessive token usage
+        if len(content) > 600:
+            content = content[:600] + "... [truncated]"
+        lines.append(f"[{prefix}]: {content}")
+
+    context = "\n".join(lines)
+    return (
+        f"[Previous conversation context — use this to maintain continuity]\n"
+        f"{context}\n\n"
+        f"[Current message from user]\n"
+        f"{new_message}"
+    )
+
+
+# ── Claude Invocation ─────────────────────────────────────────────────────────
+
+async def invoke_claude(prompt: str) -> str:
+    """
+    Run `claude -p <prompt> --output-format json` as an async subprocess.
+    Returns the text response, or an error string.
+    """
+    cmd = [
+        CLAUDE_BIN,
+        "-p", prompt,
+        "--output-format", "json",
+        "--dangerously-skip-permissions",
+        "--model", "sonnet",
+    ]
+
+    logger.info(f"Invoking Claude. Prompt length: {len(prompt)} chars")
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=PROJECT_DIR,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env={**os.environ, "HOME": str(Path.home())},
+        )
+
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(),
+            timeout=CLAUDE_TIMEOUT,
+        )
+
+        if process.returncode != 0:
+            err = stderr.decode().strip()
+            logger.error(f"Claude CLI exited with code {process.returncode}: {err[:500]}")
+            return f"Cheef hit an error (exit {process.returncode}). Check logs at {LOG_FILE}"
+
+        raw = stdout.decode().strip()
+        try:
+            output = json.loads(raw)
+            result = output.get("result", "")
+            if not result:
+                logger.warning(f"Empty result in Claude output: {raw[:300]}")
+                return "Got an empty response from Cheef. Try again."
+            logger.info(f"Claude response length: {len(result)} chars")
+            return result
+        except json.JSONDecodeError:
+            # Fallback: return raw output if JSON parsing fails
+            logger.warning(f"JSON parse failed, returning raw output. First 200 chars: {raw[:200]}")
+            return raw if raw else "No response returned."
+
+    except asyncio.TimeoutError:
+        logger.error(f"Claude timed out after {CLAUDE_TIMEOUT}s")
+        return (
+            f"That took too long (>{int(CLAUDE_TIMEOUT)}s). "
+            "MCP servers may be slow or unresponsive. Try again or use a simpler request."
+        )
+    except FileNotFoundError:
+        logger.error(f"Claude binary not found at: {CLAUDE_BIN}")
+        return f"Claude CLI not found at `{CLAUDE_BIN}`. Check that Claude Code is installed."
+    except Exception as e:
+        logger.error(f"Unexpected error invoking Claude: {e}", exc_info=True)
+        return f"Something went wrong: {type(e).__name__}: {str(e)}"
+
+
+# ── Message Chunking ──────────────────────────────────────────────────────────
+
+def chunk_message(text: str, max_len: int = TELEGRAM_MAX_CHARS) -> list[str]:
+    """
+    Split long responses into Telegram-safe chunks.
+    Splits on paragraph breaks when possible to preserve readability.
+    """
+    if len(text) <= max_len:
+        return [text]
+
+    chunks = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= max_len:
+            chunks.append(remaining)
+            break
+        # Prefer splitting on double newline (paragraph break)
+        split_at = remaining.rfind("\n\n", 0, max_len)
+        if split_at == -1:
+            # Fall back to single newline
+            split_at = remaining.rfind("\n", 0, max_len)
+        if split_at == -1:
+            # Hard split at max_len
+            split_at = max_len
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:].lstrip("\n")
+
+    return chunks
+
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+
+def is_authorized(update: Update) -> bool:
+    uid = update.effective_user.id if update.effective_user else None
+    return uid == ALLOWED_USER_ID
+
+
+# ── Handlers ──────────────────────────────────────────────────────────────────
+
+async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_authorized(update):
+        return  # silent reject
+    await update.message.reply_text(
+        "Cheef is online.\n\n"
+        "Ask anything, or use:\n"
+        "• /gm — morning briefing\n"
+        "• /triage — inbox scan\n"
+        "• /my_tasks — task list\n"
+        "• /clear — reset conversation context"
+    )
+
+
+async def handle_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_authorized(update):
+        return
+    chat_id = update.effective_chat.id
+    conversation_history[chat_id].clear()
+    await update.message.reply_text("Context cleared. Fresh start.")
+
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not is_authorized(update):
+        logger.warning(
+            f"Unauthorized message from user_id={update.effective_user.id if update.effective_user else 'unknown'}"
+        )
+        return  # silent reject — don't reveal the bot exists to strangers
+
+    user_message = update.message.text
+    chat_id = update.effective_chat.id
+
+    # Show typing indicator while Claude processes
+    await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+
+    # Build prompt with rolling conversation context
+    prompt = build_prompt_with_history(chat_id, user_message)
+
+    # Store user message before invoking Claude
+    conversation_history[chat_id].append({"role": "user", "content": user_message})
+
+    # Invoke Claude (async, non-blocking)
+    response_text = await invoke_claude(prompt)
+
+    # Store Claude's response
+    conversation_history[chat_id].append({"role": "assistant", "content": response_text})
+
+    # Send response, chunking if needed
+    chunks = chunk_message(response_text)
+    for i, chunk in enumerate(chunks):
+        if i > 0:
+            await asyncio.sleep(0.3)  # brief pause between chunks
+        await update.message.reply_text(chunk)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    logger.info(f"Starting Cheef Telegram Bot (allowed_user_id={ALLOWED_USER_ID})")
+    logger.info(f"Claude binary: {CLAUDE_BIN}")
+    logger.info(f"Project dir: {PROJECT_DIR}")
+
+    app = Application.builder().token(BOT_TOKEN).build()
+
+    # Explicit command handlers
+    app.add_handler(CommandHandler("start", handle_start))
+    app.add_handler(CommandHandler("clear", handle_clear))
+
+    # Route all other text messages AND commands (like /gm, /triage, /my_tasks)
+    # through handle_message so Claude can invoke the skill
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+    app.add_handler(MessageHandler(filters.COMMAND, handle_message))  # catches /gm, /triage, etc.
+
+    app.run_polling(
+        poll_interval=1.0,          # check for new messages every 1 second
+        timeout=30,                 # long-polling timeout
+        drop_pending_updates=True,  # skip messages sent while bot was offline
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/telegram/com.cheef.telegram.plist.template
+++ b/telegram/com.cheef.telegram.plist.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cheef.telegram</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>{{HOME_DIR}}/.claude/telegram/cheef_bot.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{HOME_DIR}}/.claude/telegram</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{{HOME_DIR}}/.claude/telegram/cheef_bot.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{HOME_DIR}}/.claude/telegram/cheef_bot_error.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{{HOME_DIR}}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Restart throttle: wait 10s before restarting after a crash -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/telegram/requirements.txt
+++ b/telegram/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot[job-queue]>=20.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
Bridges Telegram messages to the local Claude Code CLI so users can access their full Chief of Staff setup — MCP servers, commands, and context — from any device.

Changes:
- telegram/cheef_bot.py: Python bot that routes Telegram messages to the Claude CLI, with rolling conversation history and response chunking
- telegram/com.cheef.telegram.plist.template: macOS launchd service template (uses {{HOME_DIR}} placeholder, substituted during install)
- telegram/.env.example: credentials template (token, user ID, paths)
- telegram/requirements.txt: python-telegram-bot + python-dotenv
- docs/telegram-setup.md: full setup guide (BotFather, user ID, install, configure, test, launchd service, troubleshooting)
- install.sh: optional Telegram setup section with pip install and launchd service install prompt (macOS only)
- README.md: add Mobile Access pillar, update file tree, add doc link
- .gitignore: add telegram/.env, __pycache__, *.pyc